### PR TITLE
Fix typo in metrics report help

### DIFF
--- a/Functions/Public/Build-PASSetMetricsReport.ps1
+++ b/Functions/Public/Build-PASSetMetricsReport.ps1
@@ -19,7 +19,7 @@ function global:Build-PASSetMetricsReport
     .PARAMETER RemoveThese
 	Removes the specified principals from the Principals column in the resulting object. This would be used
 	to remove principals that have global access and would appear on every account. This simply removes those
-	principals from being listed in the Princials property.
+        principals from being listed in the Principals property.
 
     .INPUTS
     None. You can't redirect or pipe input to this function.

--- a/Functions/Public/Consolidate-PASSets.ps1
+++ b/Functions/Public/Consolidate-PASSets.ps1
@@ -36,7 +36,7 @@ function global:Consolidate-PASSets
     .PARAMETER RemoveThese
 	Removes the specified principals from the Principals column in the resulting object. This would be used
 	to remove principals that have global access and would appear on every account. This simply removes those
-	principals from being listed in the Princials property.
+        principals from being listed in the Principals property.
 
     .INPUTS
     None. You can't redirect or pipe input to this function.


### PR DESCRIPTION
## Summary
- fix a typo in Build-PASSetMetricsReport help comment
- fix the same typo in Consolidate-PASSets help comment

## Testing
- `grep -R "Princials" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_684c39a3ef1c8320bb1052c783bf927a