### PR TITLE
Fix typo in Build-PASSetReportCard output

### DIFF
--- a/Functions/Public/Build-PASSetReportCard.ps1
+++ b/Functions/Public/Build-PASSetReportCard.ps1
@@ -216,7 +216,7 @@ function global:Build-PASSetReportCard
 		if ($SetConflicts.IsPresent)
 		{
 			# add text
-			$AnalysisOutput.Add((" >>> Set Concflicts <<<")) | Out-Null
+                        $AnalysisOutput.Add((" >>> Set Conflicts <<<")) | Out-Null
 
 			$AnalysisOutput.Add((("Number of Accounts in Set: [{0}]" -f $set.MembersUuid.Count))) | Out-Null
 


### PR DESCRIPTION
## Summary
- fix a misspelling in a status message in `Build-PASSetReportCard`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c3e6614048320878c8af00fef2d77